### PR TITLE
additional modules needed for `pytest`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,10 @@ dependencies:
   - mkdocstrings
   - pymdown-extensions
   - mkdocs-material
+  - webtest
+  - werkzeug
   - pip
   - pip:
     - gmsh
+    - requests_mock
     - "--editable=git+https://github.com/pydap/pydap.git@3f6aa190c59e3bbc6c834377a61579b20275ff69#egg=Pydap"


### PR DESCRIPTION
I am working on a local Windows machine. After building an environment with
```bash
conda env create --file environment.yml -n pyPoseidon
```
when running 
```bash
conda activate pyPoseidon
pytest
```
the following packages are missing and need to be installed:
- `webtest`
- `werkzeug`
- `requests_mock`