### PR TITLE
refactor: Introduce tools.add_mpirun_script() and enable hyperthreading

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,5 @@
+---
+
 name: pyPoseidon
 
 channels:
@@ -27,6 +29,7 @@ dependencies:
   - bump2version
   - colorlog
   - f90nml
+  - psutil
   - pytest
   - pytest-cov
   - ipympl

--- a/poetry.lock
+++ b/poetry.lock
@@ -1289,6 +1289,7 @@ tests = ["pytest (>=3.6)", "pytest-cov", "pytest-attrib", "beautifulsoup4", "req
 [package.source]
 type = "url"
 url = "https://github.com/pydap/pydap/archive/3f6aa190c59e3bbc6c834377a61579b20275ff69.zip"
+
 [[package]]
 name = "pygeos"
 version = "0.10.2"
@@ -1808,7 +1809,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.10"
-content-hash = "a843689af1656279c7f2d99fae89c675827ea36121f55ae9a57cf3fb6de46471"
+content-hash = "0e76330495b265c10b2615d6f319d906e36bcedc22c571e89ea54dd9eaa105a6"
 
 [metadata.files]
 affine = [

--- a/pyposeidon/grid.py
+++ b/pyposeidon/grid.py
@@ -21,11 +21,10 @@ import os
 import subprocess
 from pyposeidon.utils.verify import *
 import pyposeidon.boundary as pb
-import multiprocessing
+
+from . import tools
 
 logger = logging.getLogger("pyposeidon")
-
-NCORES = max(1, multiprocessing.cpu_count() - 1)
 
 DATA_PATH = os.path.dirname(pyposeidon.__file__) + "/misc/"
 
@@ -532,19 +531,12 @@ class tri2d:
             # ------------------------------------------------------------------------------
             bin_path = "schism"
 
-        ncores = 1
-        calc_dir = path
-
-        with open(calc_dir + "launchSchism.sh", "w") as f:
-            f.write("exec={}\n".format(bin_path))
-            f.write("mkdir outputs\n")
-            f.write("mpirun -N {} $exec\n".format(ncores))
-
-        # make the script executable
-        execf = calc_dir + "launchSchism.sh"
-        mode = os.stat(execf).st_mode
-        mode |= (mode & 0o444) >> 2  # copy R bits to X
-        os.chmod(execf, mode)
+        tools.create_mpirun_script(
+            target_dir=path,
+            cmd=bin_path,
+            script_name="launchSchism.sh",
+            ncores=1,
+        )
 
         # note that cwd is the folder where the executable is
         ex = subprocess.Popen(

--- a/pyposeidon/schism.py
+++ b/pyposeidon/schism.py
@@ -42,11 +42,10 @@ from pyposeidon.utils.data import data
 
 import logging
 
+from . import tools
+
 logger = logging.getLogger("pyposeidon")
 
-import multiprocessing
-
-NCORES = max(1, multiprocessing.cpu_count() - 1)
 
 # retrieve the module path
 DATA_PATH = os.path.dirname(pyposeidon.__file__) + "/misc/"
@@ -624,18 +623,11 @@ class schism:
             # ------------------------------------------------------------------------------
             bin_path = "schism"
 
-        ncores = get_value(self, kwargs, "ncores", NCORES)
-
-        with open(calc_dir + "launchSchism.sh", "w") as f:
-            f.write("exec={}\n".format(bin_path))
-            f.write("mkdir outputs\n")
-            f.write("mpirun -N {} $exec\n".format(ncores))
-
-        # make the script executable
-        execf = calc_dir + "launchSchism.sh"
-        mode = os.stat(execf).st_mode
-        mode |= (mode & 0o444) >> 2  # copy R bits to X
-        os.chmod(execf, mode)
+        tools.create_mpirun_script(
+            target_dir=calc_dir,
+            cmd=bin_path,
+            script_name="launchSchism.sh",
+        )
 
         # ---------------------------------------------------------------------
         logger.info("output done\n")
@@ -644,8 +636,6 @@ class schism:
     def run(self, **kwargs):
 
         calc_dir = get_value(self, kwargs, "rpath", "./schism/")
-
-        ncores = get_value(self, kwargs, "ncores", NCORES)
 
         # ---------------------------------------------------------------------
         logger.info("executing model\n")
@@ -751,18 +741,11 @@ class schism:
                 # ------------------------------------------------------------------------------
                 bin_path = "schism"
 
-            ncores = get_value(self, kwargs, "ncores", NCORES)
-
-            with open(calc_dir + "launchSchism.sh", "w") as f:
-                f.write("exec={}\n".format(bin_path))
-                f.write("mkdir outputs\n")
-                f.write("mpirun -N {} $exec\n".format(ncores))
-
-            # make the script executable
-            execf = calc_dir + "launchSchism.sh"
-            mode = os.stat(execf).st_mode
-            mode |= (mode & 0o444) >> 2  # copy R bits to X
-            os.chmod(execf, mode)
+            tools.create_mpirun_script(
+                target_dir=calc_dir,
+                cmd=bin_path,
+                script_name="launchSchism.sh",
+            )
 
             self.run(**kwargs)
 

--- a/pyposeidon/tools.py
+++ b/pyposeidon/tools.py
@@ -1,0 +1,58 @@
+import os
+
+import psutil
+
+
+LAUNCH_SCHISM_TEMPLATE = """
+#!/usr/bin/env bash
+#
+# launchschism.sh
+#
+# Launch schism using MPI
+
+set -euo pipefail
+
+mkdir -p outputs
+
+exec mpirun {mpirun_flags} -N {ncores} {cmd}
+""".strip()
+
+
+# From: https://stackoverflow.com/a/30463972/592289
+def make_executable(path):
+    mode = os.stat(path).st_mode
+    mode |= (mode & 0o444) >> 2  # copy R bits to X
+    os.chmod(path, mode)
+
+
+def create_mpirun_script(
+    target_dir: str,
+    cmd: str,
+    use_threads: bool = True,
+    script_name: str = "launchSchism.sh",
+    ncores: int = 0,
+) -> str:
+    """
+    Create a script for launching schism.
+
+    - if `use_threads is True`, then the CPU threads are being used and `--use-hwthreaded_cpus` is
+      passed to `mpirun`.
+    - if `use_threads is False`, then only physical CPU cores are being used.
+    """
+    if ncores < 1:
+        ncores = psutil.cpu_count(logical=use_threads)
+    if use_threads:
+        mpirun_flags = "--use-hwthread-cpus"
+    else:
+        mpirun_flags = ""
+    content = LAUNCH_SCHISM_TEMPLATE.format(
+        mpirun_flags=mpirun_flags,
+        ncores=ncores,
+        cmd=cmd,
+    )
+    # Write to disk and make executable
+    script_path = target_dir + "/" + script_name
+    with open(script_path, "w") as fd:
+        fd.write(content)
+    make_executable(script_path)
+    return script_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ branca = "^0.4"
 ipython = "^7.20"
 llvmlite = "^0.36"
 Pydap = { url = "https://github.com/pydap/pydap/archive/3f6aa190c59e3bbc6c834377a61579b20275ff69.zip" }
+psutil = "^5.8.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/tests/tools_test.py
+++ b/tests/tools_test.py
@@ -1,0 +1,36 @@
+import os
+import pathlib
+
+import psutil
+import pytest
+
+
+from pyposeidon import tools
+
+
+@pytest.mark.parametrize("use_threads", [True, False])
+def test_create_mpirun_script(tmp_path, use_threads):
+    target_dir = tmp_path.as_posix()
+    cmd = "/bin/schism"
+    script_name = "launchSchism.sh"
+    script_path = tools.create_mpirun_script(target_dir=target_dir, cmd=cmd, use_threads=use_threads)
+    assert script_path == (tmp_path / script_name).as_posix(), "script was not created"
+    assert os.access(script_path, os.X_OK), "script is not executable"
+    assert not (tmp_path / "outputs").exists(), "outputs subdirectory has not been created"
+    content = pathlib.Path(script_path).read_text()
+    assert content.endswith(cmd), "the cmd is not being used"
+    assert f"-N {psutil.cpu_count(logical=use_threads)}" in content
+
+
+@pytest.mark.parametrize("ncores", [1, 2, 44])
+def test_create_mpirun_script_ncores(tmp_path, ncores):
+    target_dir = tmp_path.as_posix()
+    cmd = "/bin/schism"
+    script_name = "launchSchism.sh"
+    script_path = tools.create_mpirun_script(target_dir=target_dir, cmd=cmd, ncores=ncores)
+    assert script_path == (tmp_path / script_name).as_posix(), "script was not created"
+    assert os.access(script_path, os.X_OK), "script is not executable"
+    assert not (tmp_path / "outputs").exists(), "outputs subdirectory has not been created"
+    content = pathlib.Path(script_path).read_text()
+    assert content.endswith(cmd), "the cmd is not being used"
+    assert f"-N {ncores}" in content


### PR DESCRIPTION
apart from the refactoring, the main change that this commit introduces
is that `mpirun` will be invoked with `--use-hwthread-cpus` by default.
This change seems to be necessary to let `mpirun` run on Ryzen CPUs.
Some relevant links are mentioned at #34.

This introduces an additional primary dependency, `psutil`. To be precise,
`psutil` was already a secondary dependency pulled by dask/distributed
so this does not really add anything extra. Nevertheless, with this commit
we promote it to a primary dependency.

Fixes #34