### PR TITLE
tests: Reduce the number of tests that download SRTM over the network

### DIFF
--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -5,54 +5,37 @@ import pytest
 from . import DATA_DIR
 
 
-# define the lat/lon window and time frame of interest
-
-
-@pytest.mark.parametrize(
+DEM_SOURCES = pytest.mark.parametrize(
     "dem_source",
     [
         pytest.param(DATA_DIR / "dem.nc", id="local netcdf"),
         pytest.param(DATA_DIR / "dem.tif", id="local geotiff"),
-        pytest.param("https://coastwatch.pfeg.noaa.gov/erddap/griddap/srtm30plus", id="url"),
     ],
 )
-@pytest.mark.parametrize(
+
+WINDOWS = pytest.mark.parametrize(
     "kwargs",
     [
-        {"lon_min": -30, "lon_max": -10.0, "lat_min": 60.0, "lat_max": 70.0},
-        {"lon_min": 175.0, "lon_max": 184.0, "lat_min": 14.5, "lat_max": 16.5},
-        {
-            "lon_min": 175.0 - 360.0,
-            "lon_max": 184.0 - 360.0,
-            "lat_min": 14.5,
-            "lat_max": 16.5,
-        },
+        # fmt: off
+        pytest.param({"lon_min": -30, "lon_max": -10.0, "lat_min": 60.0, "lat_max": 70.0}, id="local 1"),
+        pytest.param({"lon_min": 175.0, "lon_max": 184.0, "lat_min": 14.5, "lat_max": 16.5}, id="local 2"),
+        pytest.param({"lon_min": 175.0 - 360.0, "lon_max": 184.0 - 360.0, "lat_min": 14.5, "lat_max": 16.5}, id="local 3"),
+        pytest.param({"lon_min": -180.0, "lon_max": 180.0, "lat_min": -90.0, "lat_max": 90.0}, id="global 2"),
+        pytest.param({"lon_min": -360.0, "lon_max": 0, "lat_min": -90.0, "lat_max": 90.0}, id="global 1"),
+        # fmt: on
     ],
 )
-def test_answer(dem_source, kwargs):
+
+
+@DEM_SOURCES
+@WINDOWS
+def test_dem(dem_source, kwargs):
     df = pdem.dem(dem_source=dem_source, **kwargs)
     assert np.isnan(df.Dataset.elevation.values).sum() == 0
 
 
-@pytest.mark.parametrize(
-    "full",
-    [
-        {"lon_min": -180.0, "lon_max": 180.0, "lat_min": -90.0, "lat_max": 90.0},
-        {
-            "lon_min": -180.0 - 180.0,
-            "lon_max": 180.0 - 180.0,
-            "lat_min": -90.0,
-            "lat_max": 90.0,
-        },
-    ],
-)
-@pytest.mark.parametrize(
-    "local_dem_source",
-    [
-        pytest.param(DATA_DIR / "dem.nc", id="local netcdf"),
-        pytest.param(DATA_DIR / "dem.tif", id="local geotiff"),
-    ],
-)
-def test_answer_global(local_dem_source, full):
-    df = pdem.dem(dem_source=local_dem_source, **full)
+def test_dem_source_is_url():
+    dem_source = "https://coastwatch.pfeg.noaa.gov/erddap/griddap/srtm30plus"
+    kwargs = {"lon_min": 176.5, "lon_max": 177.0, "lat_min": 16.0, "lat_max": 16.5}
+    df = pdem.dem(dem_source=dem_source, **kwargs)
     assert np.isnan(df.Dataset.elevation.values).sum() == 0

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -39,3 +39,9 @@ def test_dem_source_is_url():
     kwargs = {"lon_min": 176.5, "lon_max": 177.0, "lat_min": 16.0, "lat_max": 16.5}
     df = pdem.dem(dem_source=dem_source, **kwargs)
     assert np.isnan(df.Dataset.elevation.values).sum() == 0
+
+
+def test_dem_source_is_not_specified():
+    kwargs = {"lon_min": 176.5, "lon_max": 177.0, "lat_min": 16.0, "lat_max": 16.5}
+    df = pdem.dem(**kwargs)
+    assert np.isnan(df.Dataset.elevation.values).sum() == 0


### PR DESCRIPTION
When running the tests (at least locally) the majority of the time is being
spent in downloading SRTM. With this commit we reduce the number of tests
that download the DEM data over the network (i.e. we do it with just a
single spatial window instead of multiple ones).

This should speed up the main tests by a fair bit (e.g. from ~5 minutes
down to less than 2 minutes). The tests that require `--runschism` should
not be affected.