### PR TITLE
schism: Use float32 for `spfh` and `stmp`

### DIFF
--- a/pyposeidon/schism.py
+++ b/pyposeidon/schism.py
@@ -284,7 +284,7 @@ class Schism:
 
         xx, yy = np.meshgrid(ar.longitude.data, ar.latitude.data)
 
-        zero = dask.array.zeros(ar[p].data.shape)
+        zero = dask.array.zeros_like(ar[p])
 
         date = kwargs.get("date", ar.time[0].data)
 


### PR DESCRIPTION
Fixes #157